### PR TITLE
fix(docs): Drop duplicate Installation section

### DIFF
--- a/resources/docs/Introduction.md
+++ b/resources/docs/Introduction.md
@@ -6,12 +6,6 @@
 Apache License, Version 2.0.
 
 
-Installation
-============
-
-Via CommandBox:  `install stachebox`
-
-
 Instructions
 ============
 


### PR DESCRIPTION
Remove the repeated "Installation" heading section from the stachebox docs.