### PR TITLE
🐛 FIX: Correct setting count query causing duplicate setting creation

### DIFF
--- a/interceptors/Stachebox.cfc
+++ b/interceptors/Stachebox.cfc
@@ -36,7 +36,7 @@ component{
 		var searchBuilder = getInstance( "SearchBuilder@cbelasticsearch" ).new( variables.moduleSettings.settingsIndex );
 		var uuidLib = createobject("java", "java.util.UUID");
 		defaults.each( function( setting ){
-			searchBuilder.setQuery( { "term" : { "#setting.name#" : setting.value } } );
+			searchBuilder.setQuery( { "term" : { "name.keyword" : "#setting.name#" } } );
 			if( !searchBuilder.count() ){
 				setting[ "id" ] = uuidLib.randomUUID().toString();
 				getInstance( "Document@cbelasticsearch" )


### PR DESCRIPTION
The setting count query never found the existing settings, so each setting was recreated on app reinit.

It looks like the settings index mapping changed during development, but the "count" query was left looking for the old mapping syntax.

What ends up happening is after a few months of development (i.e. lots of reinits), the settings index has thousands upon thousands of duplicate settings. The `applyCustomSettings()` method in this same interceptor then loads those duplicate settings via a search, and mementifier has to populate each object, etc. On my development machine this was adding 30+ seconds to each reinit.

See screenshot.

![Screenshot from 2021-03-09 10-01-35](https://user-images.githubusercontent.com/8106227/137146940-f2a0e17e-cd53-48bb-9d07-b77b14b73fb5.png)
