### PR TITLE
Fix z-index on left sidebar

### DIFF
--- a/resources/assets/js/layouts/inc/Sidebar.vue
+++ b/resources/assets/js/layouts/inc/Sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex transform" :class="isOpen ? 'opacity-100' : 'opacity-0 hidden'">
+  <div class="flex transform z-30" :class="isOpen ? 'opacity-100' : 'opacity-0 hidden'">
     <div
       :class="isOpen ? 'translate-x-0 ease-out' : '-translate-x-full ease-in'"
       class="fixed z-30 inset-y-0 left-0 w-64 transition duration-300 transform bg-gray-800 overflow-y-auto lg:translate-x-0 lg:static lg:inset-0"


### PR DESCRIPTION
Elements with `transform` have their own z-index stacking context, hence we need to specify `z-index` on the transformed element to prevent it from rendering behind the log graph.

![Screenshot from 2023-10-09 10-32-00](https://github.com/coldbox-modules/stachebox/assets/8106227/7f399d1a-b44e-494a-8e77-27c55d55f1a4)
