### PR TITLE
Quick fix for #8, use tiny png for token reporter

### DIFF
--- a/interceptors/Stachebox.cfc
+++ b/interceptors/Stachebox.cfc
@@ -77,7 +77,7 @@ component{
 													"lastName"  : "Reporter",
 													"email"     : reporterUsername,
 													"password"  : createUUID(),
-													"avatar"    : "data:image/png;base64,#toBase64( fileReadBinary( logoFile ) )#",
+													"avatar"    : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII",
 													"isAdministrator" : false,
 													"allowLogin" : false
 												}


### PR DESCRIPTION
For new setups this adds a tiny 10x10px png as avatar for token reporter. Token reporter should not need any avatar.