### PR TITLE
fix endless reversedFrames

### DIFF
--- a/resources/assets/js/components/entries/DefaultEntry.vue
+++ b/resources/assets/js/components/entries/DefaultEntry.vue
@@ -341,7 +341,7 @@ export default {
 			return this.entry.event.severity || 3;
 		},
 		reversedFrames(){
-			return this.entry.error.frames ? this.entry.error.frames.reverse() : []
+			return this.entry.error.frames ? [...this.entry.error.frames].reverse() : []
 		},
 		multipleOccurrences(){
 			return this.entry.occurrences && this.entry.occurrences > 1;


### PR DESCRIPTION
guess is that it is because it’s a computed property and reverse() changes the original array