### PR TITLE
Add line numbers and error highlighting to stack traces

### DIFF
--- a/resources/assets/css/inc/_styles.css
+++ b/resources/assets/css/inc/_styles.css
@@ -16,3 +16,35 @@
 .fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */ {
 	opacity: 0;
 }
+
+/* Prism line-numbers error line highlighting */
+.line-numbers.error-line-1 .line-numbers-rows span:nth-child(1) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-1 .line-numbers-rows span:nth-child(1):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-2 .line-numbers-rows span:nth-child(2) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-2 .line-numbers-rows span:nth-child(2):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-3 .line-numbers-rows span:nth-child(3) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-3 .line-numbers-rows span:nth-child(3):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-4 .line-numbers-rows span:nth-child(4) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-4 .line-numbers-rows span:nth-child(4):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-5 .line-numbers-rows span:nth-child(5) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-5 .line-numbers-rows span:nth-child(5):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-6 .line-numbers-rows span:nth-child(6) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-6 .line-numbers-rows span:nth-child(6):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-7 .line-numbers-rows span:nth-child(7) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-7 .line-numbers-rows span:nth-child(7):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-8 .line-numbers-rows span:nth-child(8) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-8 .line-numbers-rows span:nth-child(8):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-9 .line-numbers-rows span:nth-child(9) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-9 .line-numbers-rows span:nth-child(9):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-10 .line-numbers-rows span:nth-child(10) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-10 .line-numbers-rows span:nth-child(10):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-11 .line-numbers-rows span:nth-child(11) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-11 .line-numbers-rows span:nth-child(11):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-12 .line-numbers-rows span:nth-child(12) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-12 .line-numbers-rows span:nth-child(12):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-13 .line-numbers-rows span:nth-child(13) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-13 .line-numbers-rows span:nth-child(13):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-14 .line-numbers-rows span:nth-child(14) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-14 .line-numbers-rows span:nth-child(14):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }
+.line-numbers.error-line-15 .line-numbers-rows span:nth-child(15) { background-color: rgba(255, 165, 0, 0.2); }
+.line-numbers.error-line-15 .line-numbers-rows span:nth-child(15):before { background-color: rgba(255, 140, 0, 0.4); font-weight: 700; }

--- a/resources/assets/js/components/entries/DefaultEntry.vue
+++ b/resources/assets/js/components/entries/DefaultEntry.vue
@@ -260,7 +260,7 @@
 								<h3 class="stacktrace-location">
 									{{frame.filename}}:<span class="stacktrace-line-number">{{frame.lineno}}</span>
 								</h3>
-								<pre><code class="language-javascript" v-html="frameContext( frame )"></code></pre>
+								<pre :class="['line-numbers', `error-line-${getFrameErrorLine(frame)}`]" :data-start="getFrameStartLine(frame)"><code class="language-javascript" v-html="frameContext( frame )"></code></pre>
 							</div>
 						</li>
 					</ol>
@@ -304,6 +304,8 @@ import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-javastacktrace';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-sql';
+import 'prismjs/plugins/line-numbers/prism-line-numbers';
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css';
 import Tab from "../../components/Tab";
 import Tabs from "../../components/Tabs";
 import EntryExportButton from './EntryExportButton';
@@ -355,7 +357,16 @@ export default {
 			return this.entry.event.severity || 3;
 		},
 		reversedFrames(){
-			return this.entry.error.frames ? [...this.entry.error.frames].reverse() : []
+			const frames = this.entry.error.frames ? [...this.entry.error.frames].reverse() : [];
+			// Deduplicate consecutive frames with same filename and line number
+			const deduplicated = frames.filter((frame, index) => {
+				if (index === 0) return true;
+				const previousFrame = frames[index - 1];
+				return frame.filename !== previousFrame.filename || frame.lineno !== previousFrame.lineno;
+			});
+			console.log('Original frames count:', frames.length);
+			console.log('Deduplicated frames count:', deduplicated.length);
+			return deduplicated;
 		},
 		multipleOccurrences(){
 			return this.entry.occurrences && this.entry.occurrences > 1;
@@ -399,6 +410,12 @@ export default {
 		frameContext( frame ){
 			return frame.pre_context.join( "\n" ) + "\n" + frame.context_line + "\n" + frame.post_context.join( "\n" );
 		},
+		getFrameStartLine( frame ){
+			return frame.lineno && frame.pre_context ? frame.lineno - frame.pre_context.length : 1;
+		},
+		getFrameErrorLine( frame ){
+			return frame.pre_context ? frame.pre_context.length + 1 : 1;
+		},
 		loadExtraInfoFrame( content ){
 			this.$nextTick( () => this.$refs.errorIframe.contentDocument.body.innerHTML = content || this.entry.error.extrainfo );
 		},
@@ -410,7 +427,12 @@ export default {
 		}
 	},
 	mounted() {
-		Prism.highlightAll();
+		this.$nextTick(() => {
+			this.$el.querySelectorAll('pre:not(.prism-highlighted) code').forEach((codeElement) => {
+				codeElement.parentElement.classList.add('prism-highlighted');
+				Prism.highlightElement(codeElement);
+			});
+		});
 	}
 
 }


### PR DESCRIPTION
  - Import Prism line-numbers plugin
  - Add deduplication for consecutive identical stack frames
  - Show line numbers in code context with proper starting line
  - Highlight error line in orange
  - Fix Prism initialization in mounted hook